### PR TITLE
Fixed division by zero when no pixmap is loaded

### DIFF
--- a/pyqtgraph/graphicsItems/ButtonItem.py
+++ b/pyqtgraph/graphicsItems/ButtonItem.py
@@ -15,7 +15,7 @@ class ButtonItem(GraphicsObject):
         elif pixmap is not None:
             self.setPixmap(pixmap)
             
-        if width is not None:
+        if width is not None and self.pixmap.width():
             s = float(width) / self.pixmap.width()
             self.setScale(s)
         if parentItem is not None:


### PR DESCRIPTION
`QtGui.QPixmap().width() == 0`.